### PR TITLE
inclusive identities

### DIFF
--- a/docs/tutorial/getting-set-up.rst
+++ b/docs/tutorial/getting-set-up.rst
@@ -175,8 +175,8 @@ find this out by going to https://launchpad.net/~ and looking for the
 part after the `~` in the URL.
 
 Launchpad's registration process will ask you to choose a display name. It is
-encouraged for you to use your real name here so that your Ubuntu developer
-colleagues will be able to get to know you better.
+encouraged for you to use your name or known identity here so that your Ubuntu
+developer colleagues will be able to get to know you better.
 
 When you register a new account, Launchpad will send you an email with a link
 you need to open in your browser in order to verify your email address. If


### PR DESCRIPTION
The term "real name" is ambiguous. It can be interpreted as meaning someones legal name. Requiring legal name can be discriminatory. For these reasons, [the Kernel recently changed their DCO requirements](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d4563201f33a022fc0353033d9dfeb1606a88330): 
```
-using your real name (sorry, no pseudonyms or anonymous contributions.)
+using a known identity (sorry, no anonymous contributions.)
```

Please encourage Launchpad display names which use names or known identity's as the Kernel does.