### PR TITLE
Tidying up for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ po/*
 !po/*.pot
 !po/*.po
 translators.html
+docs/.sphinx/venv

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 %:
-	make -C docs $@
+	$(MAKE) -C docs $@

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
+default:
+	$(MAKE) -C docs
+
 %:
 	$(MAKE) -C docs $@

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -1,6 +1,5 @@
 furo
-m2r2
-sphinx==5.1.1
+sphinx<6.0dev
 sphinx_autobuild
 sphinx_copybutton
 sphinx_design

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,10 +35,10 @@ run:
 	. $(VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
 
 html:
-	. $(VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w .sphinx/warnings.txt
+	. $(VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
 
 epub:
-	. $(VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w .sphinx/warnings.txt
+	. $(VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)"
 
 serve:
 	cd "$(BUILDDIR)"; python3 -m http.server 8000

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,16 +32,20 @@ install:
 	$(IN_VENV); pip install --upgrade -r .sphinx/requirements.txt
 
 run:
-	$(IN_VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
 
 html:
-	$(IN_VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
 
 epub:
-	$(IN_VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)"/epub
+
+pdf:
+	$(IN_VENV); $(SPHINXBUILD) -b latex "$(SOURCEDIR)" "$(BUILDDIR)"/pdf
+	$(IN_VENV); $(MAKE) -C "$(BUILDDIR)"/pdf all-pdf
 
 serve:
-	python3 -m http.server 8000 -d "$(BUILDDIR)"
+	python3 -m http.server 8000 -d "$(BUILDDIR)"/html
 
 clean: clean-doc
 	rm -rf "$(VENVDIR)"
@@ -56,8 +60,9 @@ distclean:
 spelling: html
 	$(IN_VENV); python3 -m pyspelling -c .sphinx/spellingcheck.yaml
 
-linkcheck:
-	$(IN_VENV); $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"
+linkcheck: html epub
+	$(IN_VENV); $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"/html
+	$(IN_VENV); $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"/epub
 
 woke:
 	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,6 +48,10 @@ clean: clean-doc
 clean-doc:
 	git clean -fx "$(BUILDDIR)"
 
+distclean:
+	rm -rf "$(BUILDDIR)"
+	rm -rf "$(VENVDIR)"
+
 spelling: html
 	$(IN_VENV); python3 -m pyspelling -c .sphinx/spellingcheck.yaml
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,19 @@ IN_VENV       ?= . $(VENVDIR)/bin/activate
 
 # Put it first so that "make" without argument is like "make help".
 help:
+	@echo "The following make targets are available:"
+	@echo "* install   -- set up a virtual-env to work on documentation"
+	@echo "* run       -- watch, build and serve the documentation"
+	@echo "* html      -- build HTML output under $(BUILDDIR)/html"
+	@echo "* serve     -- serve HTML output from $(BUILDDIR)/html"
+	@echo "* epub      -- build epub output under $(BUILDDIR)/epub"
+	@echo "* pdf       -- build pdf output under $(BUILDDIR)/pdf"
+	@echo "* clean-doc -- clean built doc files"
+	@echo "* clean     -- clean full environment"
+	@echo "* spelling  -- check spelling"
+	@echo "* linkcheck -- check external links"
+	@echo "* woke      -- check inclusive language"
+	@echo "-------------------------------------------"
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 install:
@@ -19,17 +32,6 @@ install:
 	python3 -m venv $(VENVDIR)
 	$(IN_VENV); pip install --upgrade -r .sphinx/requirements.txt
 
-	@echo "---------------------------------------------------------------"
-	@echo "* watch, build and serve the documentation: make run"
-	@echo "* only build: make html"
-	@echo "* only epub: make epub"
-	@echo "* only serve: make serve"
-	@echo "* clean built doc files: make clean-doc"
-	@echo "* clean full environment: make clean"
-	@echo "* check spelling: make spelling"
-	@echo "* check links: make linkcheck"
-	@echo "* check inclusive language: make woke"
-	@echo "---------------------------------------------------------------"
 run:
 	$(IN_VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,14 +22,14 @@ install:
 	@echo "\n" \
 		"--------------------------------------------------------------- \n" \
 		"* watch, build and serve the documentation: make run \n" \
-                "* only build: make html \n" \
-                "* only epub: make epub \n" \
-                "* only serve: make serve \n" \
-                "* clean built doc files: make clean-doc \n" \
-                "* clean full environment: make clean \n" \
-            		"* check spelling: make spelling \n" \
-                "* check links: make linkcheck \n" \
-                "* check inclusive language: make woke \n" \
+		"* only build: make html \n" \
+		"* only epub: make epub \n" \
+		"* only serve: make serve \n" \
+		"* clean built doc files: make clean-doc \n" \
+		"* clean full environment: make clean \n" \
+		"* check spelling: make spelling \n" \
+		"* check links: make linkcheck \n" \
+		"* check inclusive language: make woke \n" \
 		"--------------------------------------------------------------- \n"
 run:
 	. $(VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,10 +32,10 @@ install:
 	$(IN_VENV); pip install --upgrade -r .sphinx/requirements.txt
 
 run:
-	$(IN_VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
+	$(IN_VENV); sphinx-autobuild -b html "$(SOURCEDIR)" "$(BUILDDIR)"/html
 
 html:
-	$(IN_VENV); $(SPHINXBUILD) -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
+	$(IN_VENV); $(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)"/html
 
 epub:
 	$(IN_VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)"/epub

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -25,7 +25,6 @@ help:
 	@echo "* linkcheck -- check external links"
 	@echo "* woke      -- check inclusive language"
 	@echo "-------------------------------------------"
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 install:
 	@echo "... setting up virtualenv"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,6 +8,7 @@ SOURCEDIR     ?= .
 BUILDDIR      ?= _build
 VENVDIR       ?= .sphinx/venv
 IN_VENV       ?= . $(VENVDIR)/bin/activate
+PYTHON        ?= python3
 
 
 # Put it first so that "make" without argument is like "make help".
@@ -28,7 +29,7 @@ help:
 
 install:
 	@echo "... setting up virtualenv"
-	python3 -m venv $(VENVDIR)
+	$(PYTHON) -m venv $(VENVDIR)
 	$(IN_VENV); pip install --upgrade -r .sphinx/requirements.txt
 
 run:
@@ -45,7 +46,7 @@ pdf:
 	$(IN_VENV); $(MAKE) -C "$(BUILDDIR)"/pdf all-pdf
 
 serve:
-	python3 -m http.server 8000 -d "$(BUILDDIR)"/html
+	$(PYTHON) -m http.server 8000 -d "$(BUILDDIR)"/html
 
 clean: clean-doc
 	rm -rf "$(VENVDIR)"
@@ -58,7 +59,7 @@ distclean:
 	rm -rf "$(VENVDIR)"
 
 spelling: html
-	$(IN_VENV); python3 -m pyspelling -c .sphinx/spellingcheck.yaml
+	$(IN_VENV); $(PYTHON) -m pyspelling -c .sphinx/spellingcheck.yaml
 
 linkcheck: html epub
 	$(IN_VENV); $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)"/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,13 +32,13 @@ install:
 	$(IN_VENV); pip install --upgrade -r .sphinx/requirements.txt
 
 run:
-	$(IN_VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
+	$(IN_VENV); sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
 
 html:
-	$(IN_VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
+	$(IN_VENV); $(SPHINXBUILD) -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"/html
 
 epub:
-	$(IN_VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)"/epub
+	$(IN_VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)"/epub
 
 pdf:
 	$(IN_VENV); $(SPHINXBUILD) -b latex "$(SOURCEDIR)" "$(BUILDDIR)"/pdf
@@ -61,8 +61,8 @@ spelling: html
 	$(IN_VENV); python3 -m pyspelling -c .sphinx/spellingcheck.yaml
 
 linkcheck: html epub
-	$(IN_VENV); $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"/html
-	$(IN_VENV); $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"/epub
+	$(IN_VENV); $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)"/html
+	$(IN_VENV); $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)"/epub
 
 woke:
 	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,13 +1,13 @@
 # Minimal makefile for Sphinx documentation
 #
 
-# You can set these variables from the command line, and also
-# from the environment for the first two.
+# You can set these variables from the command line or the environment
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = .
-BUILDDIR      = _build
-VENV          = .sphinx/venv/bin/activate
+SOURCEDIR     ?= .
+BUILDDIR      ?= _build
+VENVDIR       ?= .sphinx/venv
+IN_VENV       ?= . $(VENVDIR)/bin/activate
 
 
 # Put it first so that "make" without argument is like "make help".
@@ -16,52 +16,51 @@ help:
 
 install:
 	@echo "... setting up virtualenv"
-	python3 -m venv .sphinx/venv
-	. $(VENV); pip install --upgrade -r .sphinx/requirements.txt
+	python3 -m venv $(VENVDIR)
+	$(IN_VENV); pip install --upgrade -r .sphinx/requirements.txt
 
-	@echo "\n" \
-		"--------------------------------------------------------------- \n" \
-		"* watch, build and serve the documentation: make run \n" \
-		"* only build: make html \n" \
-		"* only epub: make epub \n" \
-		"* only serve: make serve \n" \
-		"* clean built doc files: make clean-doc \n" \
-		"* clean full environment: make clean \n" \
-		"* check spelling: make spelling \n" \
-		"* check links: make linkcheck \n" \
-		"* check inclusive language: make woke \n" \
-		"--------------------------------------------------------------- \n"
+	@echo "---------------------------------------------------------------"
+	@echo "* watch, build and serve the documentation: make run"
+	@echo "* only build: make html"
+	@echo "* only epub: make epub"
+	@echo "* only serve: make serve"
+	@echo "* clean built doc files: make clean-doc"
+	@echo "* clean full environment: make clean"
+	@echo "* check spelling: make spelling"
+	@echo "* check links: make linkcheck"
+	@echo "* check inclusive language: make woke"
+	@echo "---------------------------------------------------------------"
 run:
-	. $(VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); sphinx-autobuild -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
 
 html:
-	. $(VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); $(SPHINXBUILD) -c . -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)"
 
 epub:
-	. $(VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); $(SPHINXBUILD) -c . -b epub "$(SOURCEDIR)" "$(BUILDDIR)"
 
 serve:
-	cd "$(BUILDDIR)"; python3 -m http.server 8000
+	python3 -m http.server 8000 -d "$(BUILDDIR)"
 
 clean: clean-doc
-	rm -rf .sphinx/venv
+	rm -rf "$(VENVDIR)"
 
 clean-doc:
 	git clean -fx "$(BUILDDIR)"
 
 spelling: html
-	. $(VENV) ; python3 -m pyspelling -c .sphinx/spellingcheck.yaml
+	$(IN_VENV); python3 -m pyspelling -c .sphinx/spellingcheck.yaml
 
 linkcheck:
-	. $(VENV) ; $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"
+	$(IN_VENV); $(SPHINXBUILD) -c . -b linkcheck  "$(SOURCEDIR)" "$(BUILDDIR)"
 
 woke:
 	type woke >/dev/null 2>&1 || { snap install woke; exit 1; }
-	woke *.rst **/*.rst -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml
+	woke $(find -name "*.rst") -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	$(IN_VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,3 +127,27 @@ html_css_files = [
 html_js_files = [
     'js/github_issue_links.js',
 ]
+
+# -- Options for EPUB output -------------------------------------------------
+
+epub_basename = 'ubuntu-packaging-guide'
+epub_show_urls = 'no'
+
+# -- Options for PDF output --------------------------------------------------
+
+latex_engine = 'xelatex'
+latex_show_pagerefs = True
+latex_show_urls = 'footnote'
+latex_elements = {
+    'papersize': 'a4paper',
+}
+latex_documents = [
+    (
+        root_doc,
+        'ubuntu-packaging-guide.tex',
+        html_title,
+        author,
+        'manual',
+        True,
+    ),
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,14 +27,13 @@ copyright = f'Canonical Group Ltd, {datetime.date.today().year}'
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '5.1.1'
+needs_sphinx = '4.3.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 
 extensions = [
-    'm2r2',
     'sphinx_copybutton',
     'sphinx_design',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,64 +6,26 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import datetime
 import os
 import sys
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown:
-
-#sys.path.insert(0, os.path.abspath('../../'))
-#sys.path.insert(0, os.path.abspath('../'))
-#sys.path.insert(0, os.path.abspath('./'))
-#sys.path.insert(0, os.path.abspath('.'))
+import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = 'Ubuntu Packaging Guide'
-copyright = f'Canonical Group Ltd, {datetime.date.today().year}'
+author = 'Canonical Group Ltd.'
+version = '2.0'
+copyright = f'{author}, {datetime.date.today().year}'
 
 # -- General configuration ---------------------------------------------------
 
-# If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '4.3.2'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-
 extensions = [
     'sphinx_copybutton',
     'sphinx_design',
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-
-templates_path = ['_templates']
-
-html_extra_path = []
-
-# The suffix of source filenames.
-source_suffix = '.rst'
-
-# The master toctree document.
-master_doc = 'index'
-
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-
-# version = version.version_string()
-# release = version
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-
-exclude_patterns = [
-    ".sphinx/venv/*"
-]
+root_doc = 'index'
+exclude_patterns = ['.sphinx/venv/*']
 
 # Sphinx-copybutton config options:
 # 1) prompt to be stripped from copied code.
@@ -74,13 +36,9 @@ copybutton_only_copy_prompt_lines = False
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
-
 html_theme = 'furo'
 html_logo = '_static/ubuntu_logo.png'
-html_title = "Ubuntu Packaging Guide"
+html_title = 'Ubuntu Packaging Guide'
 html_theme_options = {
     'light_css_variables': {
         'color-sidebar-background-border': 'none',


### PR DESCRIPTION
This is a whole pile of commits which seem to do a lot but should (hopefully) be entirely transparent to anyone actually using the docs. Specifically:

* There are several changes to the Makefile structure; some targets are added which are required by the packaging (e.g. distclean), others are purely for convenience (to ensure a bare "make" invocation from the root offers the help text correctly)
* The venv handling is changed slightly (not from the user perspective, but just implementation) to ensure it can be overridden entirely by the packaging system (which must not use venvs when building as that would require internet access).
* The sphinx requirements are lowered to 4.3.2. This won't affect anyone using the venv, but I wanted to check it would work so that eventually we could target jammy for a backport of the packaging; it works happily so I saw no harm in leaving it there.
* The EPUB and PDF output is cleaned up a little, to include proper link references, authorship, and copyright.
* The output structure is switched from `dirhtml` to `html`. This changes a few URLs (e.g. `search/index.html` becomes `search.html`) but firstly matches what we use on ReadTheDocs anyway, and secondly is required for the debhelper packaging system.
* Finally, different formats are now built in different sub-dirs of `docs/_build` which keeps things simple when working with multiple formats (and also simplifies the packaging task greatly).