### PR TITLE
Style guide

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -23,3 +23,4 @@ support matrices, and so on.
    reference/outdated-tools.rst
    reference/common-non-technical-acronyms.rst
    reference/glossary.rst
+   reference/style-guide.rst

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -300,6 +300,63 @@ Cards
             
             Card content
 
+Tabs
+----
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code:: reStructuredText
+
+           .. tab-set::
+    
+               .. tab-item:: Label1
+                   :sync: key1
+       
+                   Content 1
+       
+               .. tab-item:: Label2
+                   :sync: key2
+       
+                    Content 2
+       
+           .. tab-set::
+       
+               .. tab-item:: Label1
+                   :sync: key1
+       
+                   Content 1
+       
+               .. tab-item:: Label2
+                   :sync: key2
+       
+                   Content 2
+     - .. tab-set::
+
+           .. tab-item:: Label1
+               :sync: key1
+   
+               Content 1
+   
+           .. tab-item:: Label2
+               :sync: key2
+   
+               Content 2
+   
+       .. tab-set::
+   
+           .. tab-item:: Label1
+               :sync: key1
+   
+               Content 1
+   
+           .. tab-item:: Label2
+               :sync: key2
+   
+               Content 2
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -280,6 +280,26 @@ Definition lists
        Term 2:
            Definition
 
+Cards
+-----
+
+.. grid:: 2
+    
+    .. grid-item::
+        :child-align: center
+
+        .. code:: reStructuredText
+
+            .. card:: Card title
+                Card content
+
+    .. grid-item::
+        :child-align: center
+
+        .. card:: Card title
+            
+            Card content
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -119,6 +119,71 @@ Adhere to the following conventions:
 - Use bold sparingly. Avoid using bold for emphasis and rather rewrite the sentence
   to get your point across.
 
+
+Notes
+-----
+
+.. grid:: 2
+    :gutter: 2
+    
+    .. grid-item::
+        :child-align: center
+
+        .. code:: reStructuredText
+
+            .. note::
+                A note.
+
+    .. grid-item-card::
+
+            .. note::
+                A note.
+
+    .. grid-item::
+        :child-align: center
+
+        .. code:: reStructuredText
+
+            .. tip::
+                A tip.
+
+    .. grid-item-card::
+
+            .. tip::
+                A tip. 
+    
+    .. grid-item::
+        :child-align: center
+
+        .. code:: reStructuredText
+
+            .. important::
+                Important information.
+
+    .. grid-item-card::
+
+            .. important::
+                Important information. 
+    
+    .. grid-item::
+        :child-align: center
+
+        .. code:: reStructuredText
+
+            .. caution::
+                This might damage your hardware!
+
+    .. grid-item-card::
+
+            .. caution::
+                This might damage your hardware!
+
+Adhere to the following conventions:
+
+- Use notes sparingly.
+- Only use the following note types: ``note``, ``tip``, ``important``, ``caution``
+- Only use a caution if there is a clear hazard of hardware damage or data loss.
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -259,6 +259,27 @@ Instead you can do this:
        
            echo "Hello, World!"
 
+Definition lists
+----------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code:: reStructuredText
+
+            Term 1:
+                Definition
+
+            Term 2:
+                Definition
+     - Term 1:
+           Definition
+       
+       Term 2:
+           Definition
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -184,6 +184,81 @@ Adhere to the following conventions:
 - Only use the following note types: ``note``, ``tip``, ``important``, ``caution``
 - Only use a caution if there is a clear hazard of hardware damage or data loss.
 
+Code blocks
+-----------
+
+To start a code block, start a code block with ``.. code::``.
+The code block must be surrounded by empty lines.
+
+When starting a code block, you can specify the code language to enforce a specific
+sytax highlighting, but in many cases, the default sytax highlighting works just fine.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code:: reStructuredText
+       
+            .. code::
+       
+                echo "Hello, World!"
+     - .. code::
+       
+           echo "Hello, World!"
+   * - .. code:: reStructuredText
+
+            .. code:: text
+       
+                echo "Hello, World!"
+     - .. code:: text
+       
+           echo "Hello, World!"
+   * - .. code:: reStructuredText
+
+            .. code:: bash
+       
+                echo "Hello, World!"
+     - .. code:: bash
+       
+           echo "Hello, World!"
+
+Fore the sake of consistency, please **do not** use the pattern:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code:: reStructuredText
+       
+            Look, after this text starts a code block::
+       
+                echo "Hello, World!"
+     - Look, after this text starts a code block::
+       
+           echo "Hello, World!"
+
+Instead you can do this:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code:: reStructuredText
+       
+            Look, after this text starts a code block:
+
+            .. code::
+       
+                echo "Hello, World!"
+     - Look, after this text starts a code block:
+
+       .. code::
+       
+           echo "Hello, World!"
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -1,2 +1,17 @@
 Ubuntu Package Guide -- Style Guide
 ===================================
+
+.. note::
+
+    This Style Guide is based on `Canonical' reStructuredText style guide`_.
+
+All documentation files should use `reStructuredText`_ (reST) syntax. Community
+contributions in `markdown`_ are welcome, but they should be reformated to reST, before
+they are merged into the main branch 
+
+For general style conventions, see the `Canonical Documentation Style Guide`_.
+
+.. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
+.. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html
+.. _Canonical Documentation Style Guide: https://docs.ubuntu.com/styleguide/en

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -86,6 +86,39 @@ Adhere to the following conventions:
 - Do not skip levels (for example, do not follow an H2 heading with an H4 heading).
 - Use sentence style for headings (capitalise only the first word).
 
+Inline formatting
+-----------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - ``*Italic*``
+     - *Italic*
+   * - ``**Bold**``
+     - **Bold**
+   * - ````code````
+     - ``code``
+   * - ``:term:`Ubuntu```
+     - :term:`Ubuntu`
+   * - ``:file:`/file/path```
+     - :file:`/file/path`
+   * - ``:manpage:`man(1)```
+     - :manpage:`man(1)`
+   * - ``:command:`command```
+     - :command:`command`
+   * - ``:kbd:`key```
+     - :kbd:`key`
+
+Adhere to the following conventions:
+
+- Use italics sparingly. Common uses for italics are titles and names (for example,
+  when referring to a section title that you cannot link to, or when introducing
+  the name for a concept).
+- Use bold sparingly. Avoid using bold for emphasis and rather rewrite the sentence
+  to get your point across.
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -357,6 +357,35 @@ Tabs
    
                Content 2
 
+More useful markup
+------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Input
+     - Output
+   * - .. code:: reStructuredText
+
+           | Line 1
+           | Line 2
+           | Line 3
+     - | Line 1
+       | Line 2
+       | Line 3
+   * - .. code:: reStructuredText
+
+           ----
+     - A horizontal line
+     
+       (for technical reasons the horizontal line can not be displayed here)
+   * - .. code:: reStructuredText
+
+           .. This is a comment
+     - 
+
+
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -11,6 +11,81 @@ they are merged into the main branch
 
 For general style conventions, see the `Canonical Documentation Style Guide`_.
 
+Headings
+--------
+
+.. grid:: 2
+    
+    .. grid-item::
+
+        .. code:: reStructuredText
+
+            Title
+            =====
+
+    .. grid-item::
+        :child-align: center
+
+        Page title and ``<h1>`` heading
+
+    .. grid-item::
+
+        .. code:: reStructuredText
+
+            Heading
+            -------   
+            
+    .. grid-item::
+        :child-align: center
+
+        ``<h2>`` heading
+    
+    .. grid-item::
+
+        .. code:: reStructuredText
+
+            Heading
+            ~~~~~~~   
+            
+    .. grid-item::
+        :child-align: center
+
+        ``<h3>`` heading
+
+    .. grid-item::
+
+        .. code:: reStructuredText
+
+            Heading
+            ^^^^^^^
+            
+    .. grid-item::
+        :child-align: center
+
+        ``<h4>`` heading        
+
+    .. grid-item::
+
+        .. code:: reStructuredText
+
+            Heading
+            .......   
+            
+
+    .. grid-item::
+        :child-align: center
+
+        ``<h5>`` heading
+
+Underlines must be the same length as the title or heading.
+
+Adhere to the following conventions:
+
+- Do not use consecutive headings without intervening text.
+- Be consistent with the characters you use for each level. Use the ones specified above.
+- Do not skip levels (for example, do not follow an H2 heading with an H4 heading).
+- Use sentence style for headings (capitalise only the first word).
+
 .. _Canonical' reStructuredText style guide: https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 .. _markdown: https://www.sphinx-doc.org/en/master/usage/markdown.html

--- a/docs/reference/style-guide.rst
+++ b/docs/reference/style-guide.rst
@@ -1,0 +1,2 @@
+Ubuntu Package Guide -- Style Guide
+===================================


### PR DESCRIPTION
To get #26 started, I created this branch that contains an incomplete style guide, inspired by https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/

So far I covered:

* Headings
* Inline formatting
* Notes
* Code blocks
* Definition lists
* Cards
* Tabs
* More useful markup

Note: This branch needs more work before it can be merged. 