### PR TITLE
Re-add config entries removed with #43

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -49,7 +49,7 @@ ogp_image = 'https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg
 # Update with the favicon for your product (default is the circle of friends)
 html_favicon = '.sphinx/_static/favicon.png'
 
-html_title = 'Ubuntu Packaging Guide'
+html_title = ''
 
 # (Some settings must be part of the html_context dictionary, while others
 #  are on root level. Don't move the settings.)

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -148,6 +148,22 @@ custom_html_js_files = []
 
 manpages_url = 'https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html'
 
+rst_prolog = '''
+.. caution::
+
+   The Packaging and Development guide is currently undergoing a major overhaul
+   to bring it up to date. The current state you are seeing now is a preview of
+   this effort.
+
+   The current version is unstable (changing URLs can occur at any time) and
+   most content is not in properly reviewed yet. Proceed with caution and be
+   aware of technical inaccuracies.
+
+   If you are an experienced packager and would like to contribute, we would
+   love for you to be involved! See :doc:`our contribution page </contribute>`
+   for details of how to join in.
+'''
+
 # Specify a reST string that is included at the end of each file.
 # If commented out, use the default (which pulls the reuse/links.txt
 # file into each reST file).

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -146,7 +146,7 @@ custom_html_js_files = []
 
 ## The following settings override the default configuration.
 
-manpages_url = 'https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html'
+manpages_url = 'https://manpages.ubuntu.com/manpages/en/man{section}/{page}.{section}.html'
 
 rst_prolog = '''
 .. caution::

--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -146,6 +146,8 @@ custom_html_js_files = []
 
 ## The following settings override the default configuration.
 
+manpages_url = 'https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html'
+
 # Specify a reST string that is included at the end of each file.
 # If commented out, use the default (which pulls the reuse/links.txt
 # file into each reST file).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,18 +1,6 @@
 Ubuntu Packaging Guide
 ======================
 
-.. important::
-
-   The Packaging and Development guide has not been updated for some time, and
-   is currently undergoing a major overhaul to bring it up to date. It does not
-   currently reflect the state of Packaging in Ubuntu and should not be used by
-   beginners to Ubuntu packaging.
-
-   As part of this overhaul we have moved the source code to a GitHub
-   repository to make contributing easier. If you are an experienced packager
-   and would like to contribute, we would love for you to be involved! See
-   :doc:`our contribution page </contribute>` for details of how to join in.
-
 Welcome to the Ubuntu Packaging and Development Guide!
 
 This is the official place for learning all about Ubuntu Development and


### PR DESCRIPTION
#43 accidentally removed the man page link template and the preview warning banner. I just noticed it after merging.

This PR re-adds them.

This PR also removes the duplicate title. (This is based on a tip from Ruth Fuchss she showed in Riga.)