### PR TITLE
Add the 'watchfiles' module for sphinx-autobuild

### DIFF
--- a/docs/build_requirements.py
+++ b/docs/build_requirements.py
@@ -79,7 +79,8 @@ if __name__ == "__main__":
         "sphinx-autobuild",
         "sphinx-copybutton",
         "sphinx-design",
-        "sphinxcontrib-jquery"
+        "sphinxcontrib-jquery",
+        "watchfiles",
     ]
     
     requirements.extend(custom_required_modules)


### PR DESCRIPTION
Adds the `watchfiles` module to `build_requirements.py` to fix a missing dep.