### PR TITLE
Fixed  broken link and add ReadTheDocs link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,17 @@ The Ubuntu Packaging Guide
 
 This guide is often one of the first things that a new Ubuntu contributor will
 look at. Helping make it better can have a big impact.
-
 The actual articles can be found under the ``docs/`` directory in rst files.
 Images can be placed in the ``docs/images/`` folder.
+The html, js and css files can be found under ``docs/_static``. 
 
-The html, js and css files can be found under ``docs/_static``. The theme used
+You can find the full documentation [here](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/).
+
+The theme used
 in these docs is the "furo" theme, which has been modified to approach a more
-Ubuntu-esque appearance. The furo documentation has `instructions on how to
-change<https://github.com/pradyunsg/furo>`_ most of the theme's functionality.
+Ubuntu-esque appearance.The furo documentation has [instructions on how to change]
+(https://github.com/pradyunsg/furo) most of the theme's functionality.
+
 
 If adding a new article, make sure to add it to the index page for the Diataxis
 section it belongs in. These indexes are in ``docs/`` and should be easy to

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,8 @@ You can find the full documentation [here](https://canonical-ubuntu-packaging-gu
 
 The theme used
 in these docs is the "furo" theme, which has been modified to approach a more
-Ubuntu-esque appearance.The furo documentation has [instructions on how to change]
-(https://github.com/pradyunsg/furo) most of the theme's functionality.
-
+Ubuntu-esque appearance.The furo documentation has `instructions on how to change 
+<https://github.com/pradyunsg/furo>`_ most of the theme's functionality.
 
 If adding a new article, make sure to add it to the index page for the Diataxis
 section it belongs in. These indexes are in ``docs/`` and should be easy to


### PR DESCRIPTION
This pull request addresses two issues in the README.rst file:

1. Fixed  the broken link 
 Corrected the markdown syntax for the Furo theme documentation link. The previous link was broken and appeared as:
    `instructions on how to change<https://github.com/pradyunsg/furo>`_
Updated to 
   `instructions on how to change <https://github.com/pradyunsg/furo>`_

2. Added Missing ReadTheDocs Link:
Added a link to the built documentation on ReadTheDocs. The link is added to the first section of the README for better accessibility.
The new line added is:
  You can find the full documentation `here <https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/>`_.

This changes improve the usability and accessibility of the README for new contributors. 


