### PR TITLE
fix(README.rst): visually broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Images can be placed in the ``docs/images/`` folder.
 The html, js and css files can be found under ``docs/_static``. The theme used
 in these docs is the "furo" theme, which has been modified to approach a more
 Ubuntu-esque appearance. The furo documentation has `instructions on how to
-change<https://github.com/pradyunsg/furo>`_ most of the theme's functionality.
+change<https://github.com/pradyunsg/furo>most of the theme's functionality.
 
 If adding a new article, make sure to add it to the index page for the Diataxis
 section it belongs in. These indexes are in ``docs/`` and should be easy to


### PR DESCRIPTION
Added a new working link to the furo theme documentation in the README