### PR TITLE
Update furo documentation link on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Images can be placed in the ``docs/images/`` folder.
 
 The html, js and css files can be found under ``docs/_static``. The theme used
 in these docs is the "furo" theme, which has been modified to approach a more
-Ubuntu-esque appearance. The furo documentation has `instructions on how to
-change<https://github.com/pradyunsg/furo>`_ most of the theme's functionality.
+Ubuntu-esque appearance. The 'furo documentation <https://github.com/pradyunsg/furo>'_ has instructions on how to
+change most of the theme's functionality.
 
 If adding a new article, make sure to add it to the index page for the Diataxis
 section it belongs in. These indexes are in ``docs/`` and should be easy to


### PR DESCRIPTION
In an effort to improve the overall look and structure of the text I went ahead and removed the separate link and created a hyperlink to the furo documentation.