### PR TITLE
Explanation/development process

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -1,9 +1,11 @@
 addons
+ABI
 API
 APIs
 balancer
 Charmhub
 CLI
+deprioritised
 dropdown
 Diátaxis
 EBS
@@ -27,6 +29,7 @@ MyST
 namespace
 namespaces
 NodePort
+Numbat
 observability
 OEM
 OLM
@@ -35,12 +38,17 @@ pre
 ReadMe
 reST
 reStructuredText
+roadmap
+Roadmap
 RTD
 subdirectories
 subtree
 subfolders
+Tahr
+toolchain
 Ubuntu
 UI
+UIF
 UUID
 VM
 YAML

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -68,7 +68,7 @@ the `"Release" topic <https://discourse.ubuntu.com/c/release/>`_.
 
 .. note::
     In the past, the Release Schedule was published in the Ubuntu Wiki.
-    See for example the `release schedule of Ubuntu 20.04 LTS (FocalFossa) <https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule>`_.
+    See for example the `release schedule of Ubuntu 20.04 LTS (Focal Fossa) <https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule>`_.
 
 During freezes, exceptions must be requested to approve changes.
 See :doc:`how to request a freeze exception </how-to/request-freeze-exception>`.

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -223,7 +223,7 @@ export translations from Launchpad and integrate them into the package.
 
 This deadline marks the date after which translations for such packages are not
 guaranteed to be included in the final release. Depending on the package and
-its maintainer's workflow, they may be exported later.
+its maintainers workflow, they may be exported later.
 
 Other packages can still be translated until the
 :ref:`LanguagePackTranslationDeadline`.

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -1,17 +1,320 @@
 Ubuntu development process
 ==========================
 
+Each release cycle follows the same general pattern, with the following
+major phases. Ubuntu contributors are expected to follow this process closely
+to ensure that their work is aligned with that of others. Because of the
+time-based release cycle, Ubuntu contributors must be well-coordinated to
+produce an on-time release.
+
+See also the article, :doc:`/explanation/releases`, for more details about the
+release cadence.
+
+Beginning a new Release
+-----------------------
+
+The Ubuntu infrastructure is prepared for a new development branch at the
+beginning of each cycle. The package build system is set up, the toolchain
+is organized, :term:`seeds` are branched, and many other pieces are made ready
+before development can properly begin. Once these preparations are made, the
+new branch is officially announced on the
+`ubuntu-devel-announce mailing list <https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-announce>`_ 
+and opened for uploads to the :doc:`/explanation/archive`.
+
+.. note::
+    See the `Ubuntu 24.04 LTS (Noble Numbat) archive opening announcement email <https://lists.ubuntu.com/archives/ubuntu-devel-announce/2023-October/001341.html>`_
+    as an example announcement for an archive opening.
+
+Planning
+--------
+
+Ubuntu contributors discuss the targeted features for each release cycle via
+the various channels (e.g., IRC, Matrix, Discourse, Launchpad). Some of these
+come from strategic priorities for the distribution as a whole, and some are
+proposed by individual developers.
+
+The broader open-source community gets together at the :term:`Ubuntu Summit` 
+(similar but different to the past 
+:term:`Ubuntu Developer Summits <Ubuntu Developer Summit>`) to share
+experiences and ideas and to inspire future exciting projects covering
+development as well as design, writing, and community leadership with a wide
+range of technical skill levels.
+
+The :term:`Canonical` teams meet after every release at the Roadmap Planning 
+Sprint to plan the roadmap for the next release and discuss how to implement
+the roadmap at the Engineering Sprint.
+
+Merging with Upstream & Feature Development
+-------------------------------------------
+
+The first phase of the release cycle is characterized by bringing new releases
+of :term:`upstream` components into Ubuntu, either directly or via 
+:doc:`Merges and Syncs from Debian </explanation/debian-merges-and-syncs>`. 
+Development of planned projects for the release often begins while merging is
+still underway, and their development is accelerated once the package archive
+is reasonably consistent and usable.
+
+The automatic import of new package versions from Debian ends at the 
+:ref:`DebianImportFreeze`.
+
+Stabilization & Deadlines (Freezes)
+-----------------------------------
+
+During development, greater caution is gradually exercised in making changes
+to Ubuntu to ensure a stable state is reached in time for the final release
+date. The typical order and length of the various freezes can be seen on the
+current Release Schedule, which is usually posted as a Discourse article under
+the `"Release" topic <https://discourse.ubuntu.com/c/release/>`_. 
+
+.. note::
+    In the past, the Release Schedule was published in the Ubuntu Wiki.
+    See for example the `release schedule of Ubuntu 20.04 LTS (FocalFossa) <https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule>`_.
+
+During freezes, exceptions must be requested to approve changes.
+See :doc:`how to request a freeze exception </how-to/request-freeze-exception>`.
+
+.. _TestingWeeks:
+
+Testing Weeks
+~~~~~~~~~~~~~
+
+During a release's development phase, testing weeks are organized to focus the
+Ubuntu community's efforts on testing Ubuntu's latest daily
+:term:`ISO images <Image>` and its :term:`flavours <Ubuntu flavours>`. These
+weeks are crucial for discovering bugs and getting early feedback about new
+features.
+
+.. note::
+    The testing weeks replaced the older practice of alpha and beta milestones.
+    For example, Ubuntu 14.04 LTS (Trusty Tahr) had Alpha 1, Alpha 2, Beta 1,
+    and Beta 2 Milestones.
+
+    See `the email <https://lists.ubuntu.com/archives/ubuntu-release/2018-April/004434.html>`_
+    that announced the process change.
+
 .. _DebianImportFreeze:
 
 Debian Import Freeze
 ~~~~~~~~~~~~~~~~~~~~
+
+The automatic import of new packages and versions of existing packages from
+Debian gets disabled. The import of a new package or version of an existing
+package from Debian has to be requested. 
+
+.. note::
+
+    The general development activity is still unrestricted until the
+    Feature Freeze; however, the Feature Freeze is often scheduled for the same
+    day.
 
 .. _FeatureFreeze:
 
 Feature Freeze (FF)
 ~~~~~~~~~~~~~~~~~~~
 
+At this point, Ubuntu developers should stop introducing new features,
+packages, and :term:`API`/:term:`ABI` changes and concentrate on fixing bugs
+in the current release in development.
+
+.. _User Interface Freeze:
+
+User Interface Freeze (UIF)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The user interface should be finalized to allow documentation writers and
+translators to work on a consistent target that doesn't render screenshots or
+documentation obsolete.
+
+After the user interface freeze, the following things are not allowed to change
+without a freeze exception:
+
+* the user interface of individual applications that are installed by default,
+* the appearance of the desktop,
+* the distribution-specific artwork,
+* all user-visible strings in the desktop and applications that are installed 
+  by default.
+
+.. _DocumentationStringFreeze:
+
+Documentation String Freeze
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Documentation strings should no longer be created or modified. This freeze
+ensures that the documentation can be accurately translated.
+
+Exceptions to this rule may be considered before release for significant and
+glaring typographical errors or exceptional circumstances.
+
+.. _KernelFeatureFreeze:
+
+Kernel Feature Freeze
+~~~~~~~~~~~~~~~~~~~~~
+
+The :term:`kernel` feature development should end at this point, and the
+kernels can be considered feature-complete for the release. From now on, only
+bugfix changes are expected.
+
+.. note::
+    The Kernel Feature Freeze occurs after the :ref:`FeatureFreeze` because
+    the Linux Kernel is typically released upstream after the Feature Freeze.
+    Additionally, the Kernel Feature Freeze is deliberately scheduled so that
+    the Beta images have a fully featured kernel suitable for testing. 
+
+.. _HardwareEnablementFreeze:
+
+Hardware Enablement Freeze
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All new hardware enablement tasks for devices targeting the given release
+should be finished, and all the respective packages should be in the Ubuntu
+package archive. The release team will no longer accept changes in the Ubuntu
+package archive related to supporting new image types or platforms.
+This freeze ensures that any new platforms are already available for testing
+of the beta images and in the weeks leading to the :ref:`FinalFreeze`.
+
+.. note::
+    The Hardware Enablement Freeze is usually scheduled for the same day as
+    the Beta Freeze.
+
+.. _BetaFreeze:
+
+Beta Freeze
+~~~~~~~~~~~
+
+For the beta release's preparation, all uploads are queued and subject to
+manual approval by the release team. Changes to packages that affect beta
+release images (flavours included) require release team approval before
+uploading. Uploads for packages that do not affect images will generally be
+accepted as time permits.
+
+.. tip::
+    You can use the :manpage:`seeded-in-ubuntu(1)` tool, provided by the
+    ``ubuntu-dev-tools`` package, to list all the current daily images
+    containing a specified package or to determine whether the specified
+    package is part of the supported seed. 
+    
+    If the outputted list is empty, uploading it during a freeze should be
+    safe.
+
+The freeze allows Archive Admins to fix package inconsistencies or critical
+bugs quickly and in an isolated manner. Once the beta release is shipped, the 
+Beta Freeze restrictions no longer apply.
+
+.. _KernelFreeze:
+
+Kernel Freeze
+~~~~~~~~~~~~~
+
+The Kernel Freeze is a deadline for kernel updates since they require several
+lockstep actions that must be folded into the image-building process.
+
+Exceptional circumstances may justify exemptions to the freeze at the
+discretion of the release managers.
+
+.. _NonLanguagePackTranslationDeadline:
+
+Non Language Pack Translation Deadline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some translation data cannot currently be updated via the language pack
+mechanism. Because these items require more disruptive integration work,
+they are subject to an earlier deadline to give time to developers to manually
+export translations from Launchpad and integrate them into the package.
+
+This deadline marks the date after which translations for such packages are not
+guaranteed to be included in the final release. Depending on the package and
+its maintainer's workflow, they may be exported later.
+
+Other packages can still be translated until the
+:ref:`LanguagePackTranslationDeadline`.
+
+.. _FinalFreeze:
+
+Final Freeze
+~~~~~~~~~~~~
+
+This freeze marks an **extremely** high-caution period until the
+:ref:`FinalRelease`. Only bug fixes for release-critical, security-critical or
+otherwise exceptional circumstantial bugs are included in the Final Release,
+which the release team and relevant section teams must confirm.
+
+Unseeded packages
+^^^^^^^^^^^^^^^^^
+
+Packages in :ref:`ArchiveComponents_Universe` that aren't seeded in any of the
+Ubuntu flavours just remain in :ref:`FeatureFreeze` because they do not affect
+the release; however, when the Ubuntu package archive is frozen, fixes must be
+manually reviewed and accepted by the release team members.
+
+When the Final Release is close (~1.5 days out), developers should consider
+uploading to the :ref:`proposed pocket <ArchivePockets_Proposed>`, from which
+the release team will cherry-pick into the
+:ref:`release pocket <ArchivePockets_Release>` if circumstances allow.
+All packages uploaded to the proposed pocket that do not make it into the
+release pocket until the Final Release will become candidates for
+:ref:`StableReleaseUpdates_Summary`. Therefore, uploads to the proposed pocket
+during Final Freeze should meet the requirements of Stable Release Updates if
+the upload is not accepted into the release pocket. In particular, the upload
+must reference at least one bug, which will be used to track the stable update. 
+
+If you are sure that your upload will be accepted during Final Freeze, you can
+upload directly to the release pocket, but be aware that you have to re-upload
+after Final Release if the upload gets rejected.
+
+.. _ReleaseCandidate:
+
+Release Candidate
+~~~~~~~~~~~~~~~~~
+
+The images produced during the week before the :ref:`FinalRelease` are
+considered "release candidates". In an ideal world, the first release candidate
+would end up being the Final Release; however, we don't live in a perfect
+world, and this week is used to get rid of the last release-critical bugs and
+do as much testing as possible. Until the Final Release, changes are only
+permitted at the release team's discretion and will only be allowed for
+high-priority bugs that might justify delaying the release.
+
+.. _LanguagePackTranslationDeadline:
+
+Language Pack Translation Deadline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Translations done up until this date will be included in the final release's
+language packs. 
+
+Finalization
+------------
+
+As the final release approaches, the focus narrows to fixing "showstopper"
+bugs and thoroughly validating the installation images. Every image is tested
+to ensure that the installation methods work as advertised. Low-impact bugs
+and other issues are deprioritized to focus developers on this effort.
+
+This phase is vital, as severe bugs that affect the experience of booting
+or installing the images must be fixed before the final release.
+In contrast, ordinary bugs affecting the installed system can be fixed with
+Stable Release Updates.
+
 .. _FinalRelease:
 
 Final Release
 -------------
+
+Once the :ref:`ReleaseCandidate` ISO is declared stable, it will be announced on the 
+`ubuntu-announce mailing list <https://lists.ubuntu.com/archives/ubuntu-announce/>`_
+and referred to as the "Final Release".
+
+.. note::
+    See for example the `Ubuntu 24.04 LTS (Noble Numbat) release announcement <https://lists.ubuntu.com/archives/ubuntu-announce/2024-April/000301.html>`_.
+
+.. _StableReleaseUpdates_Summary:
+
+Stable Release Updates
+----------------------
+
+Released versions of Ubuntu are intended to be **stable**. This means that
+users should be able to rely on their behaviour remaining the same and
+therefore, updates are only released under particular circumstances.
+
+The dedicated :doc:`/explanation/stable-release-updates` article describes
+these criteria and the procedure for preparing such an update.

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -4,18 +4,18 @@ Ubuntu development process
 Each release cycle follows the same general pattern, with the following
 major phases. Ubuntu contributors are expected to follow this process closely
 to ensure that their work is aligned with that of others. Because of the
-time-based release cycle, Ubuntu contributors must be well-coordinated to
+time-based release cycle, Ubuntu contributors must coordinate well to
 produce an on-time release.
 
 See also the article, :doc:`/explanation/releases`, for more details about the
 release cadence.
 
-Beginning a new Release
+Beginning a new release
 -----------------------
 
 The Ubuntu infrastructure is prepared for a new development branch at the
 beginning of each cycle. The package build system is set up, the toolchain
-is organized, :term:`seeds` are branched, and many other pieces are made ready
+is organised, :term:`seeds` are branched, and many other pieces are made ready
 before development can properly begin. Once these preparations are made, the
 new branch is officially announced on the
 `ubuntu-devel-announce mailing list <https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-announce>`_ 
@@ -23,7 +23,7 @@ and opened for uploads to the :doc:`/explanation/archive`.
 
 .. note::
     See the `Ubuntu 24.04 LTS (Noble Numbat) archive opening announcement email <https://lists.ubuntu.com/archives/ubuntu-devel-announce/2023-October/001341.html>`_
-    as an example announcement for an archive opening.
+    as an example.
 
 Planning
 --------
@@ -44,10 +44,10 @@ The :term:`Canonical` teams meet after every release at the Roadmap Planning
 Sprint to plan the roadmap for the next release and discuss how to implement
 the roadmap at the Engineering Sprint.
 
-Merging with Upstream & Feature Development
+Merging with Upstream & feature development
 -------------------------------------------
 
-The first phase of the release cycle is characterized by bringing new releases
+The first phase of the release cycle is characterised by bringing new releases
 of :term:`upstream` components into Ubuntu, either directly or via 
 :doc:`Merges and Syncs from Debian </explanation/debian-merges-and-syncs>`. 
 Development of planned projects for the release often begins while merging is
@@ -57,10 +57,10 @@ is reasonably consistent and usable.
 The automatic import of new package versions from Debian ends at the 
 :ref:`DebianImportFreeze`.
 
-Stabilization & Deadlines (Freezes)
------------------------------------
+Stabilisation and deadlines (freezes)
+-------------------------------------
 
-During development, greater caution is gradually exercised in making changes
+During development, caution is increasingly exercised in making changes
 to Ubuntu to ensure a stable state is reached in time for the final release
 date. The typical order and length of the various freezes can be seen on the
 current Release Schedule, which is usually posted as a Discourse article under
@@ -75,10 +75,10 @@ See :doc:`how to request a freeze exception </how-to/request-freeze-exception>`.
 
 .. _TestingWeeks:
 
-Testing Weeks
+Testing weeks
 ~~~~~~~~~~~~~
 
-During a release's development phase, testing weeks are organized to focus the
+During a release's development phase, testing weeks are organised to focus the
 Ubuntu community's efforts on testing Ubuntu's latest daily
 :term:`ISO images <Image>` and its :term:`flavours <Ubuntu flavours>`. These
 weeks are crucial for discovering bugs and getting early feedback about new
@@ -87,7 +87,7 @@ features.
 .. note::
     The testing weeks replaced the older practice of alpha and beta milestones.
     For example, Ubuntu 14.04 LTS (Trusty Tahr) had Alpha 1, Alpha 2, Beta 1,
-    and Beta 2 Milestones.
+    and Beta 2 milestones.
 
     See `the email <https://lists.ubuntu.com/archives/ubuntu-release/2018-April/004434.html>`_
     that announced the process change.
@@ -113,15 +113,15 @@ Feature Freeze (FF)
 ~~~~~~~~~~~~~~~~~~~
 
 At this point, Ubuntu developers should stop introducing new features,
-packages, and :term:`API`/:term:`ABI` changes and concentrate on fixing bugs
-in the current release in development.
+packages, and :term:`API`/:term:`ABI` changes, and instead concentrate on
+fixing bugs in the current release in development.
 
 .. _User Interface Freeze:
 
 User Interface Freeze (UIF)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The user interface should be finalized to allow documentation writers and
+The user interface should be finalised to allow documentation writers and
 translators to work on a consistent target that doesn't render screenshots or
 documentation obsolete.
 
@@ -183,7 +183,7 @@ Beta Freeze
 
 For the beta release's preparation, all uploads are queued and subject to
 manual approval by the release team. Changes to packages that affect beta
-release images (flavours included) require release team approval before
+release images (flavours included) require the release team's approval before
 uploading. Uploads for packages that do not affect images will generally be
 accepted as time permits.
 
@@ -193,7 +193,7 @@ accepted as time permits.
     containing a specified package or to determine whether the specified
     package is part of the supported seed. 
     
-    If the outputted list is empty, uploading it during a freeze should be
+    If the list output is empty, uploading it during a freeze should be
     safe.
 
 The freeze allows Archive Admins to fix package inconsistencies or critical
@@ -213,7 +213,7 @@ discretion of the release managers.
 
 .. _NonLanguagePackTranslationDeadline:
 
-Non Language Pack Translation Deadline
+Non-language-pack translation deadline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some translation data cannot currently be updated via the language pack
@@ -276,19 +276,19 @@ high-priority bugs that might justify delaying the release.
 
 .. _LanguagePackTranslationDeadline:
 
-Language Pack Translation Deadline
+Language pack translation deadline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Translations done up until this date will be included in the final release's
 language packs. 
 
-Finalization
+Finalisation
 ------------
 
 As the final release approaches, the focus narrows to fixing "showstopper"
 bugs and thoroughly validating the installation images. Every image is tested
 to ensure that the installation methods work as advertised. Low-impact bugs
-and other issues are deprioritized to focus developers on this effort.
+and other issues are deprioritised to focus developers on this effort.
 
 This phase is vital, as severe bugs that affect the experience of booting
 or installing the images must be fixed before the final release.

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -62,7 +62,7 @@ Stabilisation and deadlines (freezes)
 
 During development, caution is increasingly exercised in making changes
 to Ubuntu to ensure a stable state is reached in time for the final release
-date. Modifications to the Ubuntu package archive get incrementaly restricted,
+date. Modifications to the Ubuntu package archive get incrementally restricted,
 effectively freezing the state of the Ubuntu package archive. The
 deadlines when these restrictions get enabled are called "freezes". During
 freezes, exceptions must be requested to approve changes. See 

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -7,7 +7,7 @@ to ensure that their work is aligned with that of others. Because of the
 time-based release cycle, Ubuntu contributors must coordinate well to
 produce an on-time release.
 
-See also the article, :doc:`/explanation/releases`, for more details about the
+See also the article :doc:`/explanation/releases` for more details about the
 release cadence.
 
 Beginning a new release
@@ -36,52 +36,49 @@ proposed by individual developers.
 The broader open-source community gets together at the :term:`Ubuntu Summit` 
 (similar but different to the past 
 :term:`Ubuntu Developer Summits <Ubuntu Developer Summit>`) to share
-experiences and ideas and to inspire future exciting projects covering
+experiences and ideas and to inspire future projects covering
 development as well as design, writing, and community leadership with a wide
 range of technical skill levels.
 
-The :term:`Canonical` teams meet after every release at the Roadmap Planning 
-Sprint to plan the roadmap for the next release and discuss how to implement
-the roadmap at the Engineering Sprint.
 
-Merging with Upstream & feature development
--------------------------------------------
+Merging with upstream and feature development
+---------------------------------------------
 
 The first phase of the release cycle is characterised by bringing new releases
 of :term:`upstream` components into Ubuntu, either directly or via 
-:doc:`Merges and Syncs from Debian </explanation/debian-merges-and-syncs>`. 
-Development of planned projects for the release often begins while merging is
-still underway, and their development is accelerated once the package archive
+:doc:`Merges and syncs from Debian </explanation/debian-merges-and-syncs>`. 
+The development of planned projects for the release often begins while merging is
+still underway, and the development accelerates once the package archive
 is reasonably consistent and usable.
 
 The automatic import of new package versions from Debian ends at the 
 :ref:`DebianImportFreeze`.
 
-Stabilisation and deadlines (freezes)
--------------------------------------
+Stabilisation and milestones (freezes)
+--------------------------------------
 
-During development, caution is increasingly exercised in making changes
-to Ubuntu to ensure a stable state is reached in time for the final release
-date. Modifications to the Ubuntu package archive get incrementally restricted,
-effectively freezing the state of the Ubuntu package archive. The
-deadlines when these restrictions get enabled are called "freezes". During
-freezes, exceptions must be requested to approve changes. See 
+Developers should increasingly exercise caution in making changes to Ubuntu to
+ensure a stable state is reached in time for the final release date.
+Archive admins incrementally restrict modifications to the Ubuntu package
+archive, effectively freezing the state of the Ubuntu package archive. The
+milestones when these restrictions get enabled are called "freezes".
+During freezes, developers must request exceptions to approve changes. See 
 :doc:`how to request a freeze exception </how-to/request-freeze-exception>`.
-The typical order and length of the various freezes can be seen on the
-current Release Schedule, which is usually posted as a Discourse article under
-the `"Release" topic <https://discourse.ubuntu.com/c/release/>`_.
+The release team usually posts the current Release Schedule as a Discourse
+article under the `"Release" topic <https://discourse.ubuntu.com/c/release/>`_.
+It shows the typical order and length of the various freezes.
 
 .. note::
     In the past, the Release Schedule was published in the Ubuntu Wiki.
-    See for example the `release schedule of Ubuntu 20.04 LTS (Focal Fossa) <https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule>`_.
+    See, for example, the `release schedule of Ubuntu 20.04 LTS (Focal Fossa) <https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule>`_.
 
 .. _TestingWeeks:
 
 Testing weeks
 ~~~~~~~~~~~~~
 
-During a release's development phase, testing weeks are organised to focus the
-Ubuntu community's efforts on testing Ubuntu's latest daily
+During a release's development phase, the release team organise testing weeks to
+focus the Ubuntu community's efforts on testing Ubuntu's latest daily
 :term:`ISO images <Image>` and its :term:`flavours <Ubuntu flavours>`. These
 weeks are crucial for discovering bugs and getting early feedback about new
 features.
@@ -99,9 +96,9 @@ features.
 Debian Import Freeze
 ~~~~~~~~~~~~~~~~~~~~
 
-The automatic import of new packages and versions of existing packages from
-Debian gets disabled. The import of a new package or version of an existing
-package from Debian has to be requested. 
+Archive admins disable the automatic import of new packages and versions of
+existing packages from Debian. The import of a new package or version of an
+existing package from Debian has to be requested. 
 
 .. note::
 
@@ -130,11 +127,11 @@ documentation obsolete.
 After the user interface freeze, the following things are not allowed to change
 without a freeze exception:
 
-* the user interface of individual applications that are installed by default,
-* the appearance of the desktop,
-* the distribution-specific artwork,
-* all user-visible strings in the desktop and applications that are installed 
-  by default.
+* User interface of individual applications that are installed by default
+* Appearance of the desktop
+* Distribution-specific artwork
+* All user-visible strings in the desktop and applications that are installed 
+  by default
 
 .. _DocumentationStringFreeze:
 
@@ -144,8 +141,8 @@ Documentation String Freeze
 Documentation strings should no longer be created or modified. This freeze
 ensures that the documentation can be accurately translated.
 
-Exceptions to this rule may be considered before release for significant and
-glaring typographical errors or exceptional circumstances.
+Exceptions to this rule may be considered before the release for significant and
+glaring errors or exceptional circumstances.
 
 .. _KernelFeatureFreeze:
 
@@ -169,7 +166,7 @@ Hardware Enablement Freeze
 
 All new hardware enablement tasks for devices targeting the given release
 should be finished, and all the respective packages should be in the Ubuntu
-package archive. The release team will no longer accept changes in the Ubuntu
+package archive. The release team no longer accepts changes in the Ubuntu
 package archive related to supporting new image types or platforms.
 This freeze ensures that any new platforms are already available for testing
 of the beta images and in the weeks leading to the :ref:`FinalFreeze`.
@@ -183,10 +180,10 @@ of the beta images and in the weeks leading to the :ref:`FinalFreeze`.
 Beta Freeze
 ~~~~~~~~~~~
 
-For the beta release's preparation, all uploads are queued and subject to
+In preparation for the beta release, all uploads are queued and subject to
 manual approval by the release team. Changes to packages that affect beta
 release images (flavours included) require the release team's approval before
-uploading. Uploads for packages that do not affect images will generally be
+uploading. Uploads for packages that do not affect images are generally
 accepted as time permits.
 
 .. tip::
@@ -207,7 +204,7 @@ Beta Freeze restrictions no longer apply.
 Kernel Freeze
 ~~~~~~~~~~~~~
 
-The Kernel Freeze is a deadline for kernel updates since they require several
+The Kernel Freeze is the final date for kernel updates because they require several
 lockstep actions that must be folded into the image-building process.
 
 Exceptional circumstances may justify exemptions to the freeze at the
@@ -223,7 +220,7 @@ mechanism. Because these items require more disruptive integration work,
 they are subject to an earlier deadline to give time to developers to manually
 export translations from Launchpad and integrate them into the package.
 
-This deadline marks the date after which translations for such packages are not
+This marks the date after which translations for such packages are not
 guaranteed to be included in the final release. Depending on the package and
 its maintainers workflow, they may be exported later.
 
@@ -244,24 +241,25 @@ Unseeded packages
 ^^^^^^^^^^^^^^^^^
 
 Packages in :ref:`ArchiveComponents_Universe` that aren't seeded in any of the
-Ubuntu flavours just remain in :ref:`FeatureFreeze` because they do not affect
+Ubuntu flavours remain in :ref:`FeatureFreeze` because they do not affect
 the release; however, when the Ubuntu package archive is frozen, fixes must be
 manually reviewed and accepted by the release team members.
 
 When the Final Release is close (~1.5 days out), developers should consider
 uploading to the :ref:`proposed pocket <ArchivePockets_Proposed>`, from which
-the release team will cherry-pick into the
+the release team cherry-picks into the
 :ref:`release pocket <ArchivePockets_Release>` if circumstances allow.
 All packages uploaded to the proposed pocket that do not make it into the
-release pocket until the Final Release will become candidates for
+release pocket until the Final Release become candidates for
 :ref:`StableReleaseUpdates_Summary`. Therefore, uploads to the proposed pocket
 during Final Freeze should meet the requirements of Stable Release Updates if
 the upload is not accepted into the release pocket. In particular, the upload
-must reference at least one bug, which will be used to track the stable update. 
+must reference at least one bug, which is used to track the stable update. 
 
-If you are sure that your upload will be accepted during Final Freeze, you can
-upload directly to the release pocket, but be aware that you have to re-upload
-after Final Release if the upload gets rejected.
+.. note::
+    If you are sure that your upload will be accepted during Final Freeze, you can
+    upload directly to the release pocket, but be aware that you have to re-upload
+    after Final Release if the upload gets rejected.
 
 .. _ReleaseCandidate:
 
@@ -302,12 +300,12 @@ Stable Release Updates.
 Final Release
 -------------
 
-Once the :ref:`ReleaseCandidate` ISO is declared stable, it will be announced on the 
-`ubuntu-announce mailing list <https://lists.ubuntu.com/archives/ubuntu-announce/>`_
-and referred to as the "Final Release".
+Once the release team declares the :ref:`ReleaseCandidate` ISO stable and names it
+the "Final Release", a representative of the team announces it on the 
+`ubuntu-announce mailing list <https://lists.ubuntu.com/archives/ubuntu-announce/>`_.
 
 .. note::
-    See for example the `Ubuntu 24.04 LTS (Noble Numbat) release announcement <https://lists.ubuntu.com/archives/ubuntu-announce/2024-April/000301.html>`_.
+    See, for example, the `Ubuntu 24.04 LTS (Noble Numbat) release announcement <https://lists.ubuntu.com/archives/ubuntu-announce/2024-April/000301.html>`_.
 
 .. _StableReleaseUpdates_Summary:
 

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -62,16 +62,18 @@ Stabilisation and deadlines (freezes)
 
 During development, caution is increasingly exercised in making changes
 to Ubuntu to ensure a stable state is reached in time for the final release
-date. The typical order and length of the various freezes can be seen on the
+date. Modifications to the Ubuntu package archive get incrementaly restricted,
+effectively freezing the state of the Ubuntu package archive. The
+deadlines when these restrictions get enabled are called "freezes". During
+freezes, exceptions must be requested to approve changes. See 
+:doc:`how to request a freeze exception </how-to/request-freeze-exception>`.
+The typical order and length of the various freezes can be seen on the
 current Release Schedule, which is usually posted as a Discourse article under
-the `"Release" topic <https://discourse.ubuntu.com/c/release/>`_. 
+the `"Release" topic <https://discourse.ubuntu.com/c/release/>`_.
 
 .. note::
     In the past, the Release Schedule was published in the Ubuntu Wiki.
     See for example the `release schedule of Ubuntu 20.04 LTS (Focal Fossa) <https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule>`_.
-
-During freezes, exceptions must be requested to approve changes.
-See :doc:`how to request a freeze exception </how-to/request-freeze-exception>`.
 
 .. _TestingWeeks:
 

--- a/docs/explanation/development-process.rst
+++ b/docs/explanation/development-process.rst
@@ -15,9 +15,9 @@ Beginning a new release
 
 The Ubuntu infrastructure is prepared for a new development branch at the
 beginning of each cycle. The package build system is set up, the toolchain
-is organised, :term:`seeds` are branched, and many other pieces are made ready
-before development can properly begin. Once these preparations are made, the
-new branch is officially announced on the
+is organised, :term:`seeds <Seeds>` are branched, and many other pieces are made
+ready before development can properly begin. Once these preparations are made,
+the new branch is officially announced on the
 `ubuntu-devel-announce mailing list <https://lists.ubuntu.com/mailman/listinfo/ubuntu-devel-announce>`_ 
 and opened for uploads to the :doc:`/explanation/archive`.
 

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -25,4 +25,5 @@ How do I...?
    how-to/write-patchfiles.rst
    how-to/propose-changes.rst
    how-to/use-schroots.rst
+   how-to/request-freeze-exception.rst
    how-to/merge-a-package.rst

--- a/docs/how-to/request-freeze-exception.rst
+++ b/docs/how-to/request-freeze-exception.rst
@@ -1,0 +1,2 @@
+Request a freeze exception
+==========================

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -1068,6 +1068,11 @@ Glossary
     s390x
         *Work in Progress*
 
+    Seeds
+        Seeds are lists of packages, that define which packages goes into the
+        :term:`Main` component of the :term:`Ubuntu Archive` and which packages
+        goes into the distribution :term:`images <Image>`.
+
     Series
         A *series* refers to the :term:`Packages <Package>` in the :term:`Ubuntu Archive`
         that target a specific :term:`Ubuntu` version. A *series* is usually referred


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is targeted against #53 for better readability of the diff. **Set the base to the `2.0-preview` branch before merging!**

This PR adds the initial content for the explanation article of the Ubuntu development process.

*(This PR is based on #54, fixed the spelling mistake in the branch name and rebased onto `explanation/merges-and-syncs`)*