### PR TITLE
feat: add article how-to/extract-packages.rst

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -14,6 +14,7 @@ DebSrc
 DNS
 DevOps
 Devel
+dsc
 ESM
 Endian
 Endianness

--- a/docs/how-to/_index.rst
+++ b/docs/how-to/_index.rst
@@ -27,3 +27,4 @@ How do I...?
    use-schroots
    request-freeze-exception
    merge-a-package
+   extract-packages

--- a/docs/how-to/extract-packages.rst
+++ b/docs/how-to/extract-packages.rst
@@ -61,9 +61,9 @@ Run the following command in a terminal:
 
 .. code-block:: none
 
-    dpkg-deb --extract BINARY-PACKAGE.dsc OUTPUT-DIRECTORY
+    dpkg-deb --extract BINARY-PACKAGE.deb OUTPUT-DIRECTORY
 
-``BINARY-PACKAGE.dsc``
+``BINARY-PACKAGE.deb``
     The path to the binary package control file.
 
 ``OUTPUT-DIRECTORY``
@@ -82,7 +82,7 @@ See the manual page :manpage:`dpkg-deb(1)` for further information.
 
     .. code-block:: none
 
-        dpkg-deb --contents BINARY-PACKAGE.dsc
+        dpkg-deb --contents BINARY-PACKAGE.deb
 
 .. tip::
 

--- a/docs/how-to/extract-packages.rst
+++ b/docs/how-to/extract-packages.rst
@@ -1,0 +1,91 @@
+Extract packages
+================
+
+This article demonstrates how to extract the contents of debian packages.
+
+See also the article :doc:`/explanation/package-model` for a deeper 
+understanding of package formats.
+
+.. _ExtractSourcePackage:
+
+Extract a source package 
+------------------------
+
+This section demonstrates how to extract the content of a source package.
+
+.. note::
+
+    A source package archive has the file ending `.dsc`.
+    See also the man page :manpage:`dsc(5)` for further information.
+
+.. important::
+
+    Make sure that you have the `dpkg-dev` package installed. 
+    To install it run the following commands in a terminal:
+
+    .. code-block:: bash
+
+        sudo apt update && sudo apt install dpkg-dev
+
+Run the follwong command in a terminal:
+
+.. code-block:: bash
+
+    dpkg-source --extract SOURCE-PACKAGE.dsc [OUTPUT-DIRECTORY]
+
+``SOURCE-PACKAGE.dsc``
+    The path to the source package control file.
+
+``OUTPUT-DIRECTORY`` (optional)
+    The path to the directory where to extract the content of the source
+    package to. This directory **must not** exist. If no output directory is 
+    specified the content will be extracted into a directory named 
+    ``NAME-VERSION`` (where ``NAME`` is the name of the source package and 
+    ``VERSION`` its version) under the current working directory.
+
+See the man page :manpage:`dpkg-source(1)` for further informations.
+
+.. _ExtractBinaryPackage:
+
+Extract a binary package
+------------------------
+
+This section demonstrates how to extract the content a binary packages.
+
+.. note::
+
+    A binary package archive has the file ending `.deb`.
+    See also the man page :manpage:`deb(5)` for further information.
+
+Run the follwong command in a terminal:
+
+.. code-block:: bash
+
+    dpkg-deb --extract BINARY-PACKAGE.dsc OUTPUT-DIRECTORY
+
+``BINARY-PACKAGE.dsc``
+    The path to the binary package control file.
+
+``OUTPUT-DIRECTORY``
+    The path to the directory where to extract the content of the binary
+    package to. In comparison to :ref:`ExtractSourcePackage` this directory
+    can already exist and even contain files.
+
+See the man page :manpage:`dpkg-deb(1)` for further informations.
+
+.. tip::
+
+    Using ``--vextract`` instead of ``--extract`` will also display
+    the extracted files to :term:`standard output <Standard Output>`.
+
+    To just list the contained files use the ``--contents`` option:
+
+    .. code-block:: bash
+
+        dpkg-deb --contents BINARY-PACKAGE.dsc
+
+.. tip::
+
+    You can also replace ``dpkg-deb`` with ``dpkg`` for the examples 
+    demonstarted here. ``dpkg`` will forward the options to ``dpkg-deb``. 
+    See the man page :manpage:`dpkg(1)` for further informations.

--- a/docs/how-to/extract-packages.rst
+++ b/docs/how-to/extract-packages.rst
@@ -1,7 +1,7 @@
 Extract packages
 ================
 
-This article demonstrates how to extract the contents of debian packages.
+This article demonstrates how to extract the contents of Debian packages.
 
 See also the article :doc:`/explanation/package-model` for a deeper 
 understanding of package formats.
@@ -15,21 +15,21 @@ This section demonstrates how to extract the content of a source package.
 
 .. note::
 
-    A source package archive has the file ending `.dsc`.
-    See also the man page :manpage:`dsc(5)` for further information.
+    A source package archive has the file extension `.dsc`.
+    See also the manual page :manpage:`dsc(5)` for further information.
 
 .. important::
 
     Make sure that you have the `dpkg-dev` package installed. 
-    To install it run the following commands in a terminal:
+    To install it, run the following commands in a terminal:
 
-    .. code-block:: bash
+    .. code-block:: none
 
         sudo apt update && sudo apt install dpkg-dev
 
-Run the follwong command in a terminal:
+Run the following command in a terminal:
 
-.. code-block:: bash
+.. code-block:: none
 
     dpkg-source --extract SOURCE-PACKAGE.dsc [OUTPUT-DIRECTORY]
 
@@ -39,27 +39,27 @@ Run the follwong command in a terminal:
 ``OUTPUT-DIRECTORY`` (optional)
     The path to the directory where to extract the content of the source
     package to. This directory **must not** exist. If no output directory is 
-    specified the content will be extracted into a directory named 
+    specified, the content is extracted into a directory named 
     ``NAME-VERSION`` (where ``NAME`` is the name of the source package and 
     ``VERSION`` its version) under the current working directory.
 
-See the man page :manpage:`dpkg-source(1)` for further informations.
+See the manual page :manpage:`dpkg-source(1)` for further information.
 
 .. _ExtractBinaryPackage:
 
 Extract a binary package
 ------------------------
 
-This section demonstrates how to extract the content a binary packages.
+This section demonstrates how to extract the content a binary package.
 
 .. note::
 
-    A binary package archive has the file ending `.deb`.
-    See also the man page :manpage:`deb(5)` for further information.
+    A binary package archive has the file extension `.deb`.
+    See also the manual page :manpage:`deb(5)` for further information.
 
-Run the follwong command in a terminal:
+Run the following command in a terminal:
 
-.. code-block:: bash
+.. code-block:: none
 
     dpkg-deb --extract BINARY-PACKAGE.dsc OUTPUT-DIRECTORY
 
@@ -68,24 +68,24 @@ Run the follwong command in a terminal:
 
 ``OUTPUT-DIRECTORY``
     The path to the directory where to extract the content of the binary
-    package to. In comparison to :ref:`ExtractSourcePackage` this directory
+    package to. In comparison to :ref:`ExtractSourcePackage`, this directory
     can already exist and even contain files.
 
-See the man page :manpage:`dpkg-deb(1)` for further informations.
+See the manual page :manpage:`dpkg-deb(1)` for further information.
 
 .. tip::
 
-    Using ``--vextract`` instead of ``--extract`` will also display
+    Using ``--vextract`` instead of ``--extract`` also outputs a list of
     the extracted files to :term:`standard output <Standard Output>`.
 
-    To just list the contained files use the ``--contents`` option:
+    To just list the files that the package contains, use the ``--contents`` option:
 
-    .. code-block:: bash
+    .. code-block:: none
 
         dpkg-deb --contents BINARY-PACKAGE.dsc
 
 .. tip::
 
     You can also replace ``dpkg-deb`` with ``dpkg`` for the examples 
-    demonstarted here. ``dpkg`` will forward the options to ``dpkg-deb``. 
-    See the man page :manpage:`dpkg(1)` for further informations.
+    demonstrated here. ``dpkg`` forwards the options to ``dpkg-deb``. 
+    See the manual page :manpage:`dpkg(1)` for further information.


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is targeted against #65 for better readability of the diff. **Set the base to the `2.0-preview` branch before merging!**

This adds a new how-to article that demonstrates how to extract the contained files in a source/binary package.