### PR TITLE
Don't send users to the middle of the Ubuntu Maintainers guide for merging

### DIFF
--- a/docs/tutorial/merge-a-package.rst
+++ b/docs/tutorial/merge-a-package.rst
@@ -2,7 +2,7 @@ Merge a package from Debian
 ===========================
 
 This article is still work in progress. You can use the
-`Ubuntu Maintainer Handbook <https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/PackageMerging.md#build-source-package>`_
+`Ubuntu Maintainer Handbook <https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/PackageMerging.md>`_
 in the meantime.
 
 .. note::


### PR DESCRIPTION
I found it surprising to be sent in the middle of the package merging guide from the ubuntu-maintainers-handbook.

I'm opening the PR against the default branch (i.e., 2.0-preview) because there's no main branch or anything alike (see https://github.com/canonical/ubuntu-packaging-guide/issues/90)