### PR TITLE
migarte to sphinx tabs (again)

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -164,7 +164,7 @@ custom_linkcheck_anchors_ignore_for_url = []
 # not need to be added here: myst_parser, sphinx_copybutton, sphinx_design,
 # sphinx_reredirects, sphinxcontrib.jquery, sphinxext.opengraph
 custom_extensions = [
-    #'sphinx_tabs.tabs',
+    'sphinx_tabs.tabs',
     #'canonical.youtube-links',
     #'canonical.related-links',
     #'canonical.custom-rst-roles',

--- a/docs/explanation/archive.rst
+++ b/docs/explanation/archive.rst
@@ -252,9 +252,9 @@ Country mirrors are accessible via the domain name format:
 You can see which mirror is the country mirror by doing a simple
 :term:`DNS` lookup. For example:
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: Finland (FI)
+    .. tab:: Finland (FI)
 
         .. code:: bash
 
@@ -267,7 +267,7 @@ You can see which mirror is the country mirror by doing a simple
 
         Therefore, ``mirrors.nic.funet.fi`` is Finland's country mirror.
 
-    .. tab-item:: Tunisia (TN)
+    .. tab:: Tunisia (TN)
 
         Tunisia does not have any third-party mirrors in its country. Therefore the
         Tunisia country mirror is just the primary Ubuntu package archive server

--- a/docs/how-to/get-package-source.rst
+++ b/docs/how-to/get-package-source.rst
@@ -183,10 +183,9 @@ The :term:`APT` package manager can also fetch source packages.
 Basic usage
 ~~~~~~~~~~~
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: apt
-        :sync: apt
+    .. group-tab:: apt
 
         .. code-block:: none
 
@@ -194,8 +193,7 @@ Basic usage
 
         You can find further information on the manual page :manpage:`apt(8)`.
 
-    .. tab-item:: apt-get
-        :sync: apt-get
+    .. group-tab:: apt-get
 
         .. code-block:: none
 
@@ -206,21 +204,15 @@ Basic usage
 Example
 ~~~~~~~
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: apt
-        :sync: apt
+    .. code-tab:: bash apt
 
-        .. code-block:: bash
+        apt source 'hello'
 
-            apt source 'hello'
+    .. code-tab:: bash apt-get
 
-    .. tab-item:: apt-get
-        :sync: apt-get
-
-        .. code-block:: bash
-
-            apt-get source 'hello'
+        apt-get source 'hello'
 
 ``dget``
 --------

--- a/docs/how-to/install-built-packages.rst
+++ b/docs/how-to/install-built-packages.rst
@@ -32,10 +32,9 @@ packages on an Ubuntu installation.
 Install ``.deb`` files
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: apt
-        :sync: apt
+    .. group-tab:: apt
 
         You can install one or multiple ``.deb`` files by using :command:`apt install` command:
 
@@ -51,8 +50,7 @@ Install ``.deb`` files
         
             sudo apt install 'hello_2.10-3_amd64.deb'
 
-    .. tab-item:: apt-get
-        :sync: apt-get
+    .. group-tab:: apt-get
 
         You can install one or multiple ``.deb`` files by using :command:`apt-get install` command:
 
@@ -68,8 +66,7 @@ Install ``.deb`` files
         
             sudo apt-get install hello_2.10-3_amd64.deb
 
-    .. tab-item:: dpkg
-        :sync: dpkg
+    .. group-tab:: dpkg
 
         You can install one or multiple ``.deb`` files by using :command:`dpkg --install` command:
 
@@ -99,10 +96,9 @@ packages.
 Keep the configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: apt
-        :sync: apt
+    .. group-tab:: apt
     
         You can uninstall one or multiple packages and **keep** their configuration
         files by using the :command:`apt remove` command:
@@ -118,8 +114,7 @@ Keep the configuration files
         
             sudo apt remove hello
 
-    .. tab-item:: apt-get
-        :sync: apt-get
+    .. group-tab:: apt-get
     
         You can uninstall one or multiple packages and **keep** their configuration
         files by using the :command:`apt-get remove` command:
@@ -136,8 +131,7 @@ Keep the configuration files
             sudo apt-get remove hello
 
 
-    .. tab-item:: dpkg
-        :sync: dpkg
+    .. group-tab:: dpkg
 
         You can uninstall one or multiple packages and **keep** their configuration
         files by using the :command:`dpkg --remove` command:
@@ -156,10 +150,9 @@ Keep the configuration files
 Delete the configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: apt
-        :sync: apt
+    .. group-tab:: apt
 
         You can uninstall one or multiple packages and **delete** their configuration
         files by using the :command:`apt purge` command:
@@ -175,8 +168,7 @@ Delete the configuration files
         
             sudo apt purge hello
 
-    .. tab-item:: apt-get
-        :sync: apt-get
+    .. group-tab:: apt-get
 
         You can uninstall one or multiple packages and **delete** their configuration
         files by using the :command:`apt-get purge` command:
@@ -192,8 +184,7 @@ Delete the configuration files
         
             sudo apt-get purge hello
 
-    .. tab-item:: dpkg
-        :sync: dpkg
+    .. group-tab:: dpkg
 
         You can uninstall one or multiple packages and **delete** their configuration
         files by using the :command:`dpkg --purge` command:
@@ -242,21 +233,15 @@ For example, to add the Launchpad PPA with the name ``hello`` of the Launchpad u
 
 Then, you can install, just as normal, the ``hello`` package contained in the PPA:
 
-.. tab-set::
+.. tabs::
 
-    .. tab-item:: apt
-        :sync: apt
+    .. code-tab:: bash apt
 
-        .. code-block:: bash
+        sudo apt install hello
 
-            sudo apt install hello
-
-    .. tab-item:: apt-get
-        :sync: apt-get
-
-        .. code-block:: bash
-
-            sudo apt-get install hello
+    .. code-tab:: bash apt-get
+        
+        sudo apt-get install hello
 
 See the :manpage:`add-apt-repository(1)` manual page for more details.
 
@@ -303,39 +288,27 @@ The steps to add the PPA are as follows:
 
 3. Update the package information:
    
-   .. tab-set::
+   .. tabs::
 
-      .. tab-item:: apt
-          :sync: apt
+       .. code-tab:: bash apt
   
-          .. code-block:: bash
+           sudo apt update
   
-              sudo apt update
-  
-      .. tab-item:: apt-get
-          :sync: apt-get
-  
-          .. code-block:: bash
-  
-              sudo apt-get update
+       .. code-tab:: bash apt-get
+            
+           sudo apt-get update
 
 4. Install the package from the PPA:
 
-   .. tab-set::
+   .. tabs::
 
-      .. tab-item:: apt
-          :sync: apt
+      .. code-tab:: bash apt
   
-          .. code-block:: bash
+          sudo apt install PACKAGE-NAME
   
-              sudo apt install PACKAGE-NAME
+      .. code-tab:: bash apt-get
   
-      .. tab-item:: apt-get
-          :sync: apt-get
-  
-          .. code-block:: bash
-  
-              sudo apt-get PACKAGE-NAME
+          sudo apt-get PACKAGE-NAME
 
 For example, here is the full script to add the Launchpad PPA named ``hello``
 of the user ``dviererbe`` and install the ``hello`` package from it.


### PR DESCRIPTION
I was going through old unused branches to clean them up an noticed that #50 was never merged into the main branch. It got accidentally merged into a wrong branch.

Note the following comment in the description of the #50:
> Note: Until PR https://github.com/canonical/ubuntu-packaging-guide/pull/49 is merged this PR will show the branch `FR-6485-sync-with-canonical-sphinx-docs-starter-pack` as it's merge target. This is just to better see the diff.

... well, guess who forget to change the merge target to `2.0-preview` 😅

**note:** because the original PR was already reviewed (and I just rebased the commit) – I will go ahead and merge directly.
