### PR TITLE
fix: ls -1 debhelper_* -> hello_*

### DIFF
--- a/docs/explanation/package-model.rst
+++ b/docs/explanation/package-model.rst
@@ -131,7 +131,7 @@ When you now run :manpage:`ls(1)`:
 
 .. code:: bash
 
-    ls -1 debhelper_*
+    ls -1 hello_*
 
 you should see the following files:
 


### PR DESCRIPTION
Fix typo.

The section is for `pull-lp-source --download-only 'hello' '2.10-3'` so it should be `ls -1 hello_*`