### PR TITLE
Makefile glossary entry

### DIFF
--- a/docs/reference/debian-dir-overview.rst
+++ b/docs/reference/debian-dir-overview.rst
@@ -246,7 +246,7 @@ The :file:`rules` file
 ----------------------
 
 The :file:`debian/rules` file does all the work for creating our package. It is
-a Makefile with targets to compile and install the application, then create the
+a :term:`Makefile` with targets to compile and install the application, then create the
 :file:`.deb` file from the installed files. It also has a target to clean up all
 the build files so you end up with just a source package again.
 

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -840,6 +840,14 @@ Glossary
     Maintainer
         *Work in Progress*
 
+    Makefile
+        A Makefile declares a set of tasks to be automatically executed. Makefiles are
+        most commonly used to describe how a program is compiled, installed, cleaned,
+        and uninstalled. The actions the Makefile performs in order to achieve these
+        tasks consist of :term:`Shell` commands.
+
+        See also: `GNU Make Documentation <https://www.gnu.org/software/make/manual/make.html#Introduction>`_
+
     Masters of the Universe
         *Work in Progress*
 


### PR DESCRIPTION
I noticed that the `d/rules` section of the `debian/` dir overview describes `d/rules` as a Makefile without defining what a Makefile was. To remedy this, I added "Makefile" as a glossary entry and linked to it in the `d/rules` article.