### PR TITLE
docs: Add reference documentation for Debian Policy

### DIFF
--- a/docs/reference/_index.rst
+++ b/docs/reference/_index.rst
@@ -11,6 +11,7 @@ support matrices, and so on.
    :titlesonly:
 
    debian-dir-overview
+   debian-policy
    architectures
    package-version-format
    launchpad-text-markup

--- a/docs/reference/debian-policy.rst
+++ b/docs/reference/debian-policy.rst
@@ -1,0 +1,79 @@
+Debian policy
+=============
+
+The Debian policy defines the requirements and guidelines for packages in the Debian distribution. It governs how packages should behave, how they interact with each other, and how they fit into the system as a whole.
+
+The policy specifies:
+
+- the structure and contents of the Debian archive
+- mandatory technical requirements for inclusion in the distribution
+- package formatting and control files
+- filesystem layout
+- :term:`operating system <Operating system>` design principles
+- maintainer scripts
+- inter-package relationships
+- shared library handling
+
+See the `Debian Policy Manual <https://www.debian.org/doc/debian-policy/index.html#>`_ for the latest version of the Debian policy.
+
+Policy conformance
+------------------
+
+It's recommended but not mandatory that every :term:`source package <Source Package>` should conform to the latest version of the Debian policy available at the time of the package’s last update.
+
+The ``Standards-Version`` field in the ``debian/control`` file of the source package must be filled out to indicate the version of the Debian policy that the package complies with. Also, package maintainers must review policy changes before updating this field.
+
+``debian/control`` file
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``debian/control`` file defines key metadata for source packages and :term:`binary packages <Binary Package>`. It resides in the root of the source package directory and is required for all source packages.
+
+This file consists of stanzas, which are sections of fields separated by empty lines. The first stanza defines the source package. Each following stanza describes a binary package built from that source package.
+
+Here are the required fields in the first stanza of the source package's ``debian/control`` file:
+
+- **Source:** The name of the source package, which must be unique within the Debian archive.
+- **Maintainer:** Name and email of the primary maintainer. This field is crucial for contacting the maintainer regarding issues, updates, or questions related to the package.
+- **Standards-Version:** The version of the Standard the package complies with.
+
+Recommended fields in the first stanza of the source package's ``debian/control`` file include ``Section`` and ``Priority``.
+
+For more information on ``debian/control`` files and their fields, see `Control files and their fields <https://www.debian.org/doc/debian-policy/ch-controlfields.html>`_.
+
+``Standards-Version`` field
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``Standards-Version`` field in the ``debian/control`` file indicates which version of the Debian policy the package has been reviewed against. The field must appear in the first stanza of the source package's ``debian/control`` file.
+
+The value of the field, which is the Debian policy version number, has four components:
+
+.. code-block:: text
+
+    Standards-Version: <major>.<minor>.<patch>.<subpatch>
+
+Here is a breakdown of the components:
+
+1. **Major version:** Incremented for significant policy changes requiring widespread updates.
+#. **Minor version:** Changed for substantial but less disruptive updates.
+#. **Major patch level:** Updated for any normative binding changes.
+#. **Minor patch level:** Used for non-functional fixes like typos and clarifications.
+
+Only the first three components are significant. You may include or omit the fourth.
+
+When updating an existing package, only update the Standards-Version field after reviewing the differences between the old and new policy versions and updating the package if necessary.
+
+Upgrading checklist
+~~~~~~~~~~~~~~~~~~~
+
+Before updating the Standards-Version field, follow these steps to ensure compliance:
+
+1. Check the Standards-Version value in debian/control.
+#. Review the changes introduced in newer versions. You can refer to the `Upgrading checklist <https://www.debian.org/doc/debian-policy/upgrading-checklist.html>`_ section of the Debian Policy Manual for a summary of the changes made in each version.
+#. Review relevant sections of the policy based on listed changes and apply updates only when necessary.
+#. Test the package to confirm that it builds and behaves correctly with the new standard.
+#. Update the ``Standards-Version`` field in ``debian/control`` file to the new version.
+
+Resources
+---------
+
+- `Debian Policy Manual <https://www.debian.org/doc/debian-policy/index.html#>`_


### PR DESCRIPTION
This PR adds reference documentation on the Debian policy and its relationship to the Standards-Version field in debian/control.

## What’s included

- [x] A summary of what the Debian Policy covers
- [x] A clear explanation of the Standards-Version field in the debian/control file
- [x] Details on the field’s format and its role in tracking policy compliance
- [x] An easy-to-follow checklist for upgrading the Standards-Version field

## Related issue

- [#139](https://github.com/canonical/ubuntu-packaging-guide/issues/139) – Write reference "Debian Policy"
- [#127](https://github.com/canonical/ubuntu-packaging-guide/issues/127) – Ubuntu packaging Guide 2.1 – Extend the Ubuntu packaging guide

## User stories addressed

- As a package maintainer, I want a link to the latest Debian Policy to check my package for compliance.
- As a package maintainer, I want a checklist for updating the Standards-Version field.
- As a new maintainer, I want to understand how the Standards-Version connects to the Debian Policy.
